### PR TITLE
UI: New post form scaffold (shadcn inputs)

### DIFF
--- a/src/app/b/[boardSlug]/new/page.tsx
+++ b/src/app/b/[boardSlug]/new/page.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+export default function NewPostPage() {
+  return (
+    <main className="container mx-auto p-6">
+      <div className="max-w-2xl mx-auto">
+        <Card>
+          <CardHeader>
+            <CardTitle>Submit new feature/bug</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">Title</label>
+                <Input name="title" placeholder="Short, descriptive title" required maxLength={120} />
+                <div className="text-xs text-muted-foreground mt-1">Up to 120 characters</div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Details (optional)</label>
+                <Textarea name="body" placeholder="Describe your request or report" maxLength={10000} />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button type="submit">Submit</Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}
+
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,28 @@
-import { BoardsList, type BoardItem } from "@/components/boards/BoardsList";
-import { PostsList, type PostItem } from "@/components/posts/PostsList";
+import { BoardsList, type BoardItem } from '@/components/boards/BoardsList';
+import { PostsList, type PostItem } from '@/components/posts/PostsList';
 
 async function fetchBoards(): Promise<BoardItem[]> {
   // Prefer SSR: fetch from API route which will be wired later; fallback to empty
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/boards`, { cache: "no-store" });
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/boards`,
+      { cache: 'no-store' }
+    );
     if (!res.ok) return [];
-    const data = (await res.json()) as Array<{ id: string; name: string; slug: string; description?: string | null; posts?: number }>;
-    return data.map((b) => ({ id: b.id, name: b.name, slug: b.slug, description: b.description ?? null, posts: b.posts }));
+    const data = (await res.json()) as Array<{
+      id: string;
+      name: string;
+      slug: string;
+      description?: string | null;
+      posts?: number;
+    }>;
+    return data.map((b) => ({
+      id: b.id,
+      name: b.name,
+      slug: b.slug,
+      description: b.description ?? null,
+      posts: b.posts,
+    }));
   } catch {
     return [];
   }

--- a/src/components/posts/PostsList.tsx
+++ b/src/components/posts/PostsList.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { PostCard, type PostItem } from "@/components/posts/PostCard";
-export type { PostItem } from "@/components/posts/PostCard";
+import { PostCard, type PostItem } from '@/components/posts/PostCard';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import * as React from 'react';
+export type { PostItem } from '@/components/posts/PostCard';
 
 export function PostsList({ posts }: { posts: PostItem[] }) {
   return (
@@ -19,5 +19,3 @@ export function PostsList({ posts }: { posts: PostItem[] }) {
     </Card>
   );
 }
-
-

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type Variant = "default" | "secondary" | "outline" | "ghost" | "destructive";
+type Size = "sm" | "md" | "lg";
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+  size?: Size;
+};
+
+const variantClasses: Record<Variant, string> = {
+  default: "bg-foreground text-background hover:bg-foreground/90",
+  secondary: "bg-muted text-foreground hover:bg-muted/80",
+  outline: "border border-foreground/20 hover:bg-muted/50",
+  ghost: "hover:bg-muted/50",
+  destructive: "bg-red-600 text-white hover:bg-red-700",
+};
+
+const sizeClasses: Record<Size, string> = {
+  sm: "h-9 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-11 px-5 text-base",
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "md", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "inline-flex items-center justify-center rounded-md font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+          variantClasses[variant],
+          sizeClasses[size],
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-[120px] w-full rounded-md border border-foreground/20 bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+


### PR DESCRIPTION
Adds the new post form page at /b/[boardSlug]/new using shadcn-style components.\n\n- Components: Button, Input, Textarea\n- SSR page scaffold with labels and validation attributes\n\nBuild and lint pass locally.\n\nAddresses issue #16.