### PR TITLE
UI: SSR board page and wire posts list links

### DIFF
--- a/src/app/b/[boardSlug]/page.tsx
+++ b/src/app/b/[boardSlug]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import { getBoardBySlug } from "@/server/repos/boards";
+import { listPosts, type PostStatus, type PostSort } from "@/server/repos/posts";
+import { PostsList } from "@/components/posts/PostsList";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default async function BoardPage(props: { params: Promise<{ boardSlug: string }>; searchParams?: Promise<{ status?: PostStatus; sort?: PostSort; q?: string }> }) {
+  const params = await props.params;
+  const sp = (await props.searchParams) ?? {};
+  const board = await getBoardBySlug(params.boardSlug);
+  if (!board) return notFound();
+
+  const page = 1;
+  const limit = 20;
+  const data = await listPosts({ boardId: board.id, status: sp.status, sort: sp.sort ?? "trending", query: sp.q, page, limit });
+
+  return (
+    <main className="container mx-auto p-6">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>{board.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">{board.description ?? ""}</p>
+          </CardContent>
+        </Card>
+        <PostsList posts={data.items} boardSlug={board.slug} />
+      </div>
+    </main>
+  );
+}
+
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default async function Home() {
           <BoardsList boards={boards} />
         </div>
         <div className="col-span-12 md:col-span-8">
-          <PostsList posts={posts} />
+          <PostsList posts={posts} boardSlug={boards[0]?.slug ?? 'features'} />
         </div>
       </div>
     </main>

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -26,7 +26,7 @@ function statusVariant(status: PostItem["status"]) {
   }
 }
 
-export function PostCard({ post }: { post: PostItem }) {
+export function PostCard({ post, href }: { post: PostItem; href?: string }) {
   const st = statusVariant(post.status);
   return (
     <Card className="hover:bg-muted/50 transition">
@@ -38,7 +38,13 @@ export function PostCard({ post }: { post: PostItem }) {
           <div className="flex items-center gap-2">
             <Badge variant={st.variant}>{st.label}</Badge>
           </div>
-          <div className="font-medium mt-1 line-clamp-2">{post.title}</div>
+          {href ? (
+            <a href={href} className="font-medium mt-1 line-clamp-2 hover:underline">
+              {post.title}
+            </a>
+          ) : (
+            <div className="font-medium mt-1 line-clamp-2">{post.title}</div>
+          )}
           <div className="text-xs text-muted-foreground mt-1">{post.commentCount} comments</div>
         </div>
       </CardContent>

--- a/src/components/posts/PostsList.tsx
+++ b/src/components/posts/PostsList.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import * as React from 'react';
 export type { PostItem } from '@/components/posts/PostCard';
 
-export function PostsList({ posts }: { posts: PostItem[] }) {
+export function PostsList({ posts, boardSlug }: { posts: PostItem[]; boardSlug: string }) {
   return (
     <Card className="h-full">
       <CardHeader>
@@ -13,7 +13,9 @@ export function PostsList({ posts }: { posts: PostItem[] }) {
         {posts.length === 0 ? (
           <div className="text-sm text-muted-foreground">No posts yet.</div>
         ) : (
-          posts.map((p) => <PostCard key={p.id} post={p} />)
+          posts.map((p) => (
+            <PostCard key={p.id} post={p} href={`/b/${boardSlug}/${p.slug}`} />
+          ))
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
Adds SSR board page  and wires posts list with links to post detail.\n\n- Server-rendered board page fetching from repos\n-  now links to detail\n- Home passes a default board slug for links\n\nBuild and lint pass locally.\n\nAddresses issue #15.