### PR TITLE
UI: Client new post submission + board page button

### DIFF
--- a/src/app/b/[boardSlug]/new/FormClient.tsx
+++ b/src/app/b/[boardSlug]/new/FormClient.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+export function FormClient({ boardSlug }: { boardSlug: string }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (loading) return;
+    setLoading(true);
+    setError(null);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const payload = {
+      title: String(formData.get("title") || "").trim(),
+      body: String(formData.get("body") || "").trim(),
+    };
+    if (!payload.title) {
+      setError("Title is required");
+      setLoading(false);
+      return;
+    }
+    const res = await fetch(`/api/boards/${encodeURIComponent(boardSlug)}/posts`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      setError("Failed to submit. Please try again.");
+      setLoading(false);
+      return;
+    }
+    const created = (await res.json()) as { slug: string };
+    router.push(`/b/${boardSlug}/${created.slug}`);
+  }
+
+  return (
+    <form className="space-y-4" onSubmit={onSubmit}>
+      <div>
+        <label className="block text-sm font-medium mb-1">Title</label>
+        <Input name="title" placeholder="Short, descriptive title" required maxLength={120} />
+        <div className="text-xs text-muted-foreground mt-1">Up to 120 characters</div>
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Details (optional)</label>
+        <Textarea name="body" placeholder="Describe your request or report" maxLength={10000} />
+      </div>
+      {error && <div className="text-sm text-red-600">{error}</div>}
+      <div className="flex justify-end gap-2">
+        <Button type="submit" disabled={loading}>
+          {loading ? "Submitting..." : "Submit"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+

--- a/src/app/b/[boardSlug]/new/page.tsx
+++ b/src/app/b/[boardSlug]/new/page.tsx
@@ -1,9 +1,8 @@
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { FormClient } from "./FormClient";
 
-export default function NewPostPage() {
+export default async function NewPostPage(props: { params: Promise<{ boardSlug: string }> }) {
+  const params = await props.params;
   return (
     <main className="container mx-auto p-6">
       <div className="max-w-2xl mx-auto">
@@ -12,20 +11,7 @@ export default function NewPostPage() {
             <CardTitle>Submit new feature/bug</CardTitle>
           </CardHeader>
           <CardContent>
-            <form className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium mb-1">Title</label>
-                <Input name="title" placeholder="Short, descriptive title" required maxLength={120} />
-                <div className="text-xs text-muted-foreground mt-1">Up to 120 characters</div>
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1">Details (optional)</label>
-                <Textarea name="body" placeholder="Describe your request or report" maxLength={10000} />
-              </div>
-              <div className="flex justify-end gap-2">
-                <Button type="submit">Submit</Button>
-              </div>
-            </form>
+            <FormClient boardSlug={params.boardSlug} />
           </CardContent>
         </Card>
       </div>

--- a/src/app/b/[boardSlug]/page.tsx
+++ b/src/app/b/[boardSlug]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from "next/navigation";
+import { getBoardBySlug } from "@/server/repos/boards";
+import { listPosts, type PostStatus, type PostSort } from "@/server/repos/posts";
+import { PostsList } from "@/components/posts/PostsList";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default async function BoardPage(props: { params: Promise<{ boardSlug: string }>; searchParams?: Promise<{ status?: PostStatus; sort?: PostSort; q?: string }> }) {
+  const params = await props.params;
+  const sp = (await props.searchParams) ?? {};
+  const board = await getBoardBySlug(params.boardSlug);
+  if (!board) return notFound();
+
+  const page = 1;
+  const limit = 20;
+  const data = await listPosts({ boardId: board.id, status: sp.status, sort: sp.sort ?? "trending", query: sp.q, page, limit });
+
+  return (
+    <main className="container mx-auto p-6">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>{board.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">{board.description ?? ""}</p>
+          </CardContent>
+        </Card>
+        <PostsList posts={data.items} boardSlug={board.slug} />
+      </div>
+    </main>
+  );
+}
+
+

--- a/src/app/b/[boardSlug]/page.tsx
+++ b/src/app/b/[boardSlug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from "next/navigation";
 import { getBoardBySlug } from "@/server/repos/boards";
 import { listPosts, type PostStatus, type PostSort } from "@/server/repos/posts";
 import { PostsList } from "@/components/posts/PostsList";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default async function BoardPage(props: { params: Promise<{ boardSlug: string }>; searchParams?: Promise<{ status?: PostStatus; sort?: PostSort; q?: string }> }) {
@@ -19,7 +21,12 @@ export default async function BoardPage(props: { params: Promise<{ boardSlug: st
       <div className="max-w-4xl mx-auto space-y-6">
         <Card>
           <CardHeader>
-            <CardTitle>{board.name}</CardTitle>
+            <div className="flex items-center justify-between gap-4">
+              <CardTitle>{board.name}</CardTitle>
+              <Link href={`/b/${board.slug}/new`}>
+                <Button>New post</Button>
+              </Link>
+            </div>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground">{board.description ?? ""}</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default async function Home() {
           <BoardsList boards={boards} />
         </div>
         <div className="col-span-12 md:col-span-8">
-          <PostsList posts={posts} />
+          <PostsList posts={posts} boardSlug={boards[0]?.slug ?? 'features'} />
         </div>
       </div>
     </main>

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -26,7 +26,7 @@ function statusVariant(status: PostItem["status"]) {
   }
 }
 
-export function PostCard({ post }: { post: PostItem }) {
+export function PostCard({ post, href }: { post: PostItem; href?: string }) {
   const st = statusVariant(post.status);
   return (
     <Card className="hover:bg-muted/50 transition">
@@ -38,7 +38,13 @@ export function PostCard({ post }: { post: PostItem }) {
           <div className="flex items-center gap-2">
             <Badge variant={st.variant}>{st.label}</Badge>
           </div>
-          <div className="font-medium mt-1 line-clamp-2">{post.title}</div>
+          {href ? (
+            <a href={href} className="font-medium mt-1 line-clamp-2 hover:underline">
+              {post.title}
+            </a>
+          ) : (
+            <div className="font-medium mt-1 line-clamp-2">{post.title}</div>
+          )}
           <div className="text-xs text-muted-foreground mt-1">{post.commentCount} comments</div>
         </div>
       </CardContent>

--- a/src/components/posts/PostsList.tsx
+++ b/src/components/posts/PostsList.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import * as React from 'react';
 export type { PostItem } from '@/components/posts/PostCard';
 
-export function PostsList({ posts }: { posts: PostItem[] }) {
+export function PostsList({ posts, boardSlug }: { posts: PostItem[]; boardSlug: string }) {
   return (
     <Card className="h-full">
       <CardHeader>
@@ -13,7 +13,9 @@ export function PostsList({ posts }: { posts: PostItem[] }) {
         {posts.length === 0 ? (
           <div className="text-sm text-muted-foreground">No posts yet.</div>
         ) : (
-          posts.map((p) => <PostCard key={p.id} post={p} />)
+          posts.map((p) => (
+            <PostCard key={p.id} post={p} href={`/b/${boardSlug}/${p.slug}`} />
+          ))
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
Implements client-side submission for new posts and adds a 'New post' button on the board page.\n\n- New client component handles POST to /api/boards/[slug]/posts and redirects on success\n- Board page header includes CTA linking to the form\n\nBuild and lint pass locally.\n\nAddresses issue #16.