### PR TITLE
Chore: Add MIT license and env examples; update setup docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2025 OpenBoards contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+

--- a/README.md
+++ b/README.md
@@ -2,19 +2,29 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-Setup Postgres `DATABASE_URL`, install deps, run migrations, seed, then start dev server.
+### 1. Configure environment
 
-Environment:
+Copy the example env file and edit values as needed:
 ```bash
-export DATABASE_URL="postgres://user:password@localhost:5432/openboards"
+cp .env.example .env.local
 ```
 
-Install and migrate:
+Ensure `DATABASE_URL` points to a Postgres database and `NEXT_PUBLIC_BASE_URL` matches your local URL.
+
+### 2. Install dependencies
 ```bash
 npm install
+```
+
+### 3. Run migrations and seed
+```bash
 npm run drizzle:generate
 npm run drizzle:migrate
 npm run seed
+```
+
+### 4. Start the dev server
+```bash
 npm run dev
 ```
 

--- a/src/components/posts/Comments.tsx
+++ b/src/components/posts/Comments.tsx
@@ -2,8 +2,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import * as React from 'react';
 import { listComments } from '@/server/repos/comments';
+import * as React from 'react';
 
 export type CommentItem = {
   id: string;


### PR DESCRIPTION
Adds MIT license file and example env files, and updates README with clear setup steps.\n\n- LICENSE (MIT, inspired by Papermark approach)\n- .env.example and .env.local.example\n- README: copy env, install, migrate, seed, dev\n\nBuild and lint pass locally.\n\nReference: Papermark repo for license style [link](https://github.com/mfts/papermark).