### PR TITLE
License: AGPLv3 core with EE commercial license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,29 @@
 MIT License
 
-Copyright (c) 2025 OpenBoards contributors
+Copyright (c) 2025-present OpenBoards contributors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Portions of this software are licensed as follows:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+- All content that resides under the `ee/` directory of this repository (Commercial License) is licensed under the license defined in `ee/LICENSE`.
+- All third party components incorporated into the OpenBoards Software are licensed under the original license provided by the owner of the applicable component.
+- Content outside of the above mentioned directories or restrictions above is available under the "AGPLv3" license as defined below.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
 
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
 
+Preamble
+
+The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+[... full AGPLv3 text unchanged ...]
+
+You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2025 OpenBoards contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+

--- a/README.md
+++ b/README.md
@@ -2,19 +2,29 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-Setup Postgres `DATABASE_URL`, install deps, run migrations, seed, then start dev server.
+### 1. Configure environment
 
-Environment:
+Copy the example env file and edit values as needed:
 ```bash
-export DATABASE_URL="postgres://user:password@localhost:5432/openboards"
+cp .env.example .env.local
 ```
 
-Install and migrate:
+Ensure `DATABASE_URL` points to a Postgres database and `NEXT_PUBLIC_BASE_URL` matches your local URL.
+
+### 2. Install dependencies
 ```bash
 npm install
+```
+
+### 3. Run migrations and seed
+```bash
 npm run drizzle:generate
 npm run drizzle:migrate
 npm run seed
+```
+
+### 4. Start the dev server
+```bash
 npm run dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## License
+
+- Core (outside of `ee/`): AGPLv3. See `LICENSE`.
+- Enterprise (`ee/`): commercial license. See `ee/LICENSE`.
+
+This model follows approaches used by projects like Papermark ([repo](https://github.com/mfts/papermark)).
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,7 @@
+Commercial License Placeholder
+
+The contents of this `ee/` directory are subject to a separate commercial license.
+
+For licensing inquiries, please contact: legal@openboards.dev
+
+

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "openboards",
   "version": "0.1.0",
   "private": true,
+  "license": "AGPL-3.0-only",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/src/components/posts/Comments.tsx
+++ b/src/components/posts/Comments.tsx
@@ -2,8 +2,8 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import * as React from 'react';
 import { listComments } from '@/server/repos/comments';
+import * as React from 'react';
 
 export type CommentItem = {
   id: string;


### PR DESCRIPTION
Switch core to AGPLv3 with Papermark-style preamble and add an EE commercial license placeholder.\n\n- LICENSE updated to AGPLv3 with preamble\n- ee/LICENSE placeholder for commercial code\n- package.json license field set to AGPL-3.0-only\n- README updated with dual-license notes\n\nReference: Papermark licensing approach [Papermark repo](https://github.com/mfts/papermark).\n\nBuild and lint pass locally.